### PR TITLE
Added save and get map thumbnails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ secrets.ini
 preloaded_data/raw_data/
 node_modules/
 data/
+package-lock.json
+settings.json
 
 # GitHub template from https://github.com/github/gitignore/blob/master/Python.gitignore
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "python.pythonPath": "C:\\Users\\E.Nunes\\miniconda3\\envs\\ahm-back\\python.exe",
+    "python.pythonPath": "/Users/nunes/miniconda3/envs/ahm-back/bin/python",
     "jshint.options": {"esversion": 8, "browser": true}
 }

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -219,10 +219,31 @@ async function saveMap(saveAsNew=false){
         mapDetails.mapId = choropleth.mapId;
     }
 
-    const url = `${SCRIPT_ROOT}analysis/save`;
-    const response = await postData(url, mapDetails);   //function from upload_data.js
-    choropleth.mapId = response.map_id;
+    const url = `${URL_ROOT}analysis/save`;
+    const dataResponse = await postData(url, mapDetails);   //function from upload_data.js
+    choropleth.mapId = dataResponse.map_id;
 
+    const imageResponse = await saveMapImage();
+        
+}
+
+async function saveMapImage(){
+    const mapImage = await generateMapImage();
+    const imageUrl = `${URL_ROOT}analysis/9/save-thumbnail`;
+    const imageResponse = await fetch(imageUrl, {
+        method: 'POST',
+        body: mapImage
+    });
+    return imageResponse;
+}
+
+async function generateMapImage(){
+    let node = document.getElementById('map');
+    // let img = new Image();
+    let dataUrl = await domtoimage.toJpeg(node, { quality: 0.15});
+    // img.src = dataUrl;
+    // return img;
+    return dataUrl;
 }
 
 function loadMap(choropleth, sidePanel){

--- a/app/templates/analysis.html
+++ b/app/templates/analysis.html
@@ -4,6 +4,7 @@
 <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
 <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
 <script src="http://cdn.jsdelivr.net/npm/jstat@latest/dist/jstat.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dom-to-image/2.6.0/dom-to-image.min.js"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Now when a map is saved, an image of that map is saved locally.  This process saves the image at low fidelity, but does not otherwise alter the image of the map as displayed in the browser at the time of save.  When the thumbnail is later retrieved care must be taken to adjust size and dimensions.

I also added an endpoint to retrieve the URL for the image, which can then be used as the image source in html.

This method does not scale, as it's using the same disk space the application is saved on.  This is just a proof of concept.  Later this will be updated to use an image hosting service.